### PR TITLE
Add comment "FIXME > Memory leak when using this as a callback ?"

### DIFF
--- a/lib/fine_sampling_synchronization_impl.cc
+++ b/lib/fine_sampling_synchronization_impl.cc
@@ -118,6 +118,17 @@ namespace gr {
             d_samp_inc_rem = 0;
             d_new_interpolation_ratio_rem = 0;
 
+            /** @fcarraustewart: FIXME > Memory leak when using this as a callback ? 
+             * in the context where we already constructed our block
+             * invoking this function would leave 6 dangling pointers right here, we 
+             * should somehow memory manage this correctly, on first thought:
+             * */
+            /**
+             * < Calling delete for each of the following pointers 
+             * and assigning them nullptr right here. Before running the new operator.
+             * 
+             * */
+
             // d_current_line_corr[i] and derivatives will keep the correlation between pixels 
             // px[t] and px[t+Htotal+i]
             d_current_line_corr = new gr_complex[2*d_max_deviation_px + 1];


### PR DESCRIPTION
Just noting that there is a problem here,

> During runtime, the callback can be asynchronously called, and it is allocating memory without releasing the memory assigned to the active pointers. This leaves 6 pointers with memory arrays assigned to them. 

I've got an idea on how to fix it.

1. Remove `set_Htotal_Vtotal` method call from the `constructor`.
2. Copy contents of the `set_Htotal_Vtotal` method to the `constructor` so that it still gets the same results.
3. Edit the contents of the `set_Htotal_Vtotal` method to always run the `delete` operator on the pointers before running the `new` operator on them. Now this is able to be called as an asynch callback.

**Note: Step 1 and Step 2 are needed because otherwise Step 3 makes the block crash when running the `constructor` because at the beginning of the .grc it will be calling `delete` on a fresh set of pointers. *

I tested it and it works. 